### PR TITLE
AQUA-35 Add Transaction Removal Functionality to Grid

### DIFF
--- a/src/hooks/useTransactions.ts
+++ b/src/hooks/useTransactions.ts
@@ -1,7 +1,7 @@
 "use client";
-import TransactionsState from "@/interfaces/states/transaction-state.interface";
 import { Category } from "@/types/category.types";
 import { Transaction, TransactionsAction } from "@/types/transaction.types";
+import TransactionsState from "@/interfaces/states/transaction-state.interface";
 import { useReducer } from "react";
 import { v4 as uuidv4 } from "uuid";
 
@@ -41,6 +41,14 @@ const useTransactions = () => {
           transactions: [...state.transactions, action.payload],
         };
       }
+      case "removeTransaction": {
+        return {
+          ...state,
+          transactions: state.transactions.filter(
+            (transaction) => transaction.id !== action.payload
+          ),
+        };
+      }
       case "reset": {
         return {
           version: 1,
@@ -68,6 +76,11 @@ const useTransactions = () => {
     dispatch({ type: "addSingleTransaction", payload: newExpense });
   };
 
+  const removeTransaction = (transactionId: string) => {
+    if (transactionId === "") return;
+    dispatch({ type: "removeTransaction", payload: transactionId });
+  };
+
   const addNewCategory = (newCategory: Category) => {
     dispatch({ type: "addSingleCategory", payload: newCategory });
   };
@@ -75,6 +88,7 @@ const useTransactions = () => {
   return {
     addNewCategory,
     addNewTransaction,
+    removeTransaction,
     state,
   };
 };

--- a/src/types/transaction.types.ts
+++ b/src/types/transaction.types.ts
@@ -20,6 +20,7 @@ type TransactionsAction =
   | { type: "addSingleTransaction"; payload: Transaction }
   | { type: "initializeCategories"; payload: Category[] }
   | { type: "initializeTransactions"; payload: Transaction[] }
+  | { type: "removeTransaction"; payload: string }
   | { type: "reset" };
 
 type TransactionType = "income" | "expense";


### PR DESCRIPTION
Introduces the ability to delete transactions from the TransactionGrid via a new 'Actions' column with a delete button. Updates the useTransactions hook and transaction types to support transaction removal, and provides user feedback with a toast notification upon deletion.